### PR TITLE
Fix/replace urllib with urllib.parse import

### DIFF
--- a/tests/test_mailinglists.py
+++ b/tests/test_mailinglists.py
@@ -252,7 +252,7 @@ class WebHooksTest(TestCase):
         self.factory = RequestFactory()
 
         from djangoplicity.mailinglists.models import MailChimpList, MailChimpListToken
-        from urllib import urlencode
+        from urllib.parse import urlencode
 
         list = MailChimpList(api_key=TEST_API_KEY, list_id=TEST_LIST_ID, connected=True)
         list.save()


### PR DESCRIPTION
Trying to fix this error:
![image](https://user-images.githubusercontent.com/9884128/96134148-cf569600-0ec0-11eb-948c-1856bd05f618.png)
