### PR TITLE
Upgrade/test Python versions against Django versions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -14,7 +14,8 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.7, 3.8]
+        python-version: [2.7, 3.8]
+        django-version: [1.11.21, 2.2.16]
 
     services:
       postgres:
@@ -40,6 +41,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt  --find-links https://www.djangoplicity.org/repository/packages/
+          pip install Django==${{ matrix.django-version }}
       - name: Run migrations
         run: python manage.py migrate
       - name: Run tests

--- a/requirements/requirements-essential.txt
+++ b/requirements/requirements-essential.txt
@@ -1,4 +1,4 @@
-Django==1.11.21
+Django==2.2
 setuptools
 certifi
 #django-mailman == 0.4+eso1
@@ -11,7 +11,7 @@ psycopg2-binary==2.8.5
 celery==4.4.7
 
 # Djangoplicity actions
-git+https://@github.com/djangoplicity/djangoplicity-actions@develop
+git+https://@github.com/djangoplicity/djangoplicity-actions@release/python3
 
 # Django mailman
 git+https://@github.com/jelko/django-mailman@master

--- a/requirements/requirements-essential.txt
+++ b/requirements/requirements-essential.txt
@@ -1,4 +1,4 @@
-Django==2.2
+Django==1.11.21
 setuptools
 certifi
 #django-mailman == 0.4+eso1


### PR DESCRIPTION
Python 3.7 version was removed from Github Actions and Django 2.2.16 was added.