### PR TITLE
Feature/fix offset aware datetimes

### DIFF
--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -186,7 +186,7 @@ USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = True
+USE_TZ = False
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/


### PR DESCRIPTION
We found this error that happens just on development, so I disabled the `USE_TZ` on the settings of the test project and it worked but I don't know if this is the right solution.

![Screen Shot 2020-11-13 at 10 55 45 AM](https://user-images.githubusercontent.com/9884128/99123799-eaefb200-25ce-11eb-986c-843b4f8f2999.png)

