### PR TITLE
Feature/embargo dates for newsletters including EST/EDT

### DIFF
--- a/djangoplicity/newsletters/templates/newsletters/includes/press_release.html
+++ b/djangoplicity/newsletters/templates/newsletters/includes/press_release.html
@@ -2,7 +2,8 @@
 {% if release %}{% load release_links djangoplicity_datetime djangoplicity_utils  %}
 {% if embargo %}
 <div style="padding: 10px; font-size: 18px; background-color: #f4c819; text-align: center; font-weight: bold;">
-{% trans "EMBARGOED* UNTIL"%} {{release.release_date|time4lang:"en"|datetime:"DATETIME" }}
+{% trans "EMBARGOED* UNTIL"%} {{release.release_date|time4lang:"en"|datetime:"DATETIME" }} /
+{{ release.release_date|timezone:"America/Phoenix"|timezone:"UTC"|datetime:"DATETIME" }}
 </div>
 <div style="padding: 10px; font-size: 12px; background-color: #eeeeee;">
 {% endif %}

--- a/djangoplicity/newsletters/templates/newsletters/includes/press_release.html
+++ b/djangoplicity/newsletters/templates/newsletters/includes/press_release.html
@@ -1,9 +1,9 @@
-{% load i18n %}
+{% load i18n newsletter_tags %}
 {% if release %}{% load release_links djangoplicity_datetime djangoplicity_utils  %}
 {% if embargo %}
 <div style="padding: 10px; font-size: 18px; background-color: #f4c819; text-align: center; font-weight: bold;">
-{% trans "EMBARGOED* UNTIL"%} {{release.release_date|time4lang:"en"|datetime:"DATETIME" }} /
-{{ release.release_date|timezone:"UTC"|datetime:"DATETIME" }}
+{% trans "EMBARGOED* UNTIL"%} <br>
+{{ release.release_date|dual_timezone_display }}
 </div>
 <div style="padding: 10px; font-size: 12px; background-color: #eeeeee;">
 {% endif %}

--- a/djangoplicity/newsletters/templates/newsletters/includes/press_release.html
+++ b/djangoplicity/newsletters/templates/newsletters/includes/press_release.html
@@ -3,7 +3,7 @@
 {% if embargo %}
 <div style="padding: 10px; font-size: 18px; background-color: #f4c819; text-align: center; font-weight: bold;">
 {% trans "EMBARGOED* UNTIL"%} {{release.release_date|time4lang:"en"|datetime:"DATETIME" }} /
-{{ release.release_date|timezone:"America/Phoenix"|timezone:"UTC"|datetime:"DATETIME" }}
+{{ release.release_date|timezone:"UTC"|datetime:"DATETIME" }}
 </div>
 <div style="padding: 10px; font-size: 12px; background-color: #eeeeee;">
 {% endif %}

--- a/djangoplicity/newsletters/templatetags/newsletter_tags.py
+++ b/djangoplicity/newsletters/templatetags/newsletter_tags.py
@@ -1,0 +1,36 @@
+# newsletters/templatetags/newsletter_extras.py
+
+import pytz
+from django import template
+
+register = template.Library()
+
+@register.filter
+def dual_timezone_display(value):
+    """
+    Receives a datetime (release_date) and returns a string with
+    the times in MST and EDT, displaying the full date only if it changes
+    Example 11 Sept. 2025 4:00 p.m. MST / 7:00 p.m. EDT
+    11 Sept. 2025 10:00 p.m. MST / 12 Sept 2025 1:00 a.m. EDT
+    """
+    if not value:
+        return ""
+
+    mst_zone = pytz.timezone("America/Phoenix")
+    edt_zone = pytz.timezone("America/New_York")
+
+    mst = value.astimezone(mst_zone)
+    edt = value.astimezone(edt_zone)
+
+    if mst.date() == edt.date():
+        return (
+            mst.strftime("%-d %b. %Y %-I:%M %p MST")
+            + " / "
+            + edt.strftime("%-I:%M %p %Z")
+        )
+    else:
+        return (
+            mst.strftime("%-d %b. %Y %-I:%M %p MST")
+            + " / "
+            + edt.strftime("%-d %b. %Y %-I:%M %p %Z")
+        )


### PR DESCRIPTION
Updated press_release.html newsletter template to display embargo time in both MST and UTC with proper timezone conversion.