### PR TITLE
Fix/subject being overwritten on newsletter save

### DIFF
--- a/djangoplicity/newsletters/models.py
+++ b/djangoplicity/newsletters/models.py
@@ -701,7 +701,8 @@ class Newsletter( ArchiveModel, TranslationModel ):
         if store:
             self.html = data['html']
             self.text = data['text']
-            self.subject = data['subject']
+            if not self.subject:
+                self.subject = data['subject']
 
         return data
 


### PR DESCRIPTION
I've fixed an issue where the newsletter subject line was being overwritten upon saving, preventing changes from being retained.

The `render()` method has been updated to generate the subject line only if it's empty, ensuring that manual edits by the administrator are preserved.